### PR TITLE
chore: bump runtime to 25.08 and remove bundled libusb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/so.onekey.Wallet.yml
+++ b/so.onekey.Wallet.yml
@@ -1,9 +1,9 @@
 app-id: so.onekey.Wallet
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 command: onekey-wallet
 finish-args:
   - --device=all
@@ -14,9 +14,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --socket=pcsc
 modules:
-  # https://github.com/flathub/com.yubico.yubioath/blob/546581dc3aef3d79de497cdbc4a481b537c5ab99/com.yubico.yubioath.yml#L24-L44
-  - shared-modules/libusb/libusb.json
-
   - name: pcsc-lite
     config-opts:
       - --disable-libudev


### PR DESCRIPTION
## 变更说明
- 将 Flatpak `runtime-version` 从 `23.08` 升级到 `25.08`
- 将 Electron BaseApp `base-version` 同步升级到 `25.08`
- 移除 `shared-modules/libusb/libusb.json`，因为 `libusb` 已包含在 `org.freedesktop.Platform//25.08` 运行时中

## 验证
- 使用 Python 解析 `so.onekey.Wallet.yml`，确认 manifest 语法有效
