### PR TITLE
fix: improve launcher portability and Flatpak troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,47 @@
 
 Official [Flathub package](https://flathub.org/apps/details/so.onekey.Wallet) of [OneKey Wallet](https://onekey.so/).
 
-You need to install **PCSC daemon** to use this app.
+You need to install and enable **PCSC daemon** to use this app.
 
 
 ## Install
 
 1. [Add Flathub](https://flatpak.org/setup/) to your system.
-2. Install PCSC daemon.
+2. Install and enable PCSC daemon.
 
    ```sh
-   sudo dnf install pcsc-lite
+   # Fedora
+   sudo dnf install pcsc-lite pcsc-lite-ccid
+   sudo systemctl enable --now pcscd.socket
+
+   # Debian / Ubuntu
+   sudo apt install pcscd libccid
+   sudo systemctl enable --now pcscd.socket
+
+   # Arch
+   sudo pacman -S pcsclite ccid
+   sudo systemctl enable --now pcscd.socket
    ```
 3. Install OneKey Wallet from Flathub:
 
    ```sh
    flatpak install flathub so.onekey.Wallet
    ```
+
+## Troubleshooting
+
+If network requests fail in Flatpak, check these first:
+
+```sh
+# 1) Verify the app still has network permission
+flatpak info --show-permissions so.onekey.Wallet
+
+# 2) Check whether any local override removed network access
+flatpak override --show so.onekey.Wallet
+
+# 3) Start with Electron logs enabled and check network/TLS errors
+flatpak run --env=ELECTRON_ENABLE_LOGGING=1 so.onekey.Wallet
+
+# 4) If `network` was overridden, reset/restore network permission
+flatpak override --user --share=network so.onekey.Wallet
+```

--- a/onekey-wallet.sh
+++ b/onekey-wallet.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-set -oue pipefail
+set -eu
 
 export FLATPAK_ID="${FLATPAK_ID:-so.onekey.Wallet}"
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 
 # Wayland support can be optionally enabled like so:
 # flatpak override --user --env=USE_WAYLAND=1 so.onekey.Wallet
-declare -i USE_WAYLAND="${USE_WAYLAND:-0}"
-declare -i EXIT_CODE=0
+USE_WAYLAND="${USE_WAYLAND:-0}"
+EXIT_CODE=0
 
-if [[ "${USE_WAYLAND}" -eq 1 && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
-    zypak-wrapper /app/onekey-wallet/onekey-wallet --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland $@ || EXIT_CODE=$?
+if [ "${USE_WAYLAND}" = "1" ] && [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+    zypak-wrapper /app/onekey-wallet/onekey-wallet --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland "$@" || EXIT_CODE=$?
     # Fall back to x11 if failed to launch under Wayland. Otherwise, exit normally
-    [[ "${EXIT_CODE}" -ne 133 ]] && exit "${EXIT_CODE}"
+    [ "${EXIT_CODE}" -ne 133 ] && exit "${EXIT_CODE}"
 fi
 
-zypak-wrapper /app/onekey-wallet/onekey-wallet $@
+exec zypak-wrapper /app/onekey-wallet/onekey-wallet "$@"

--- a/so.onekey.Wallet.metainfo.xml
+++ b/so.onekey.Wallet.metainfo.xml
@@ -16,7 +16,7 @@
     <p>OneKey is designed intentionally to keep things simple. That's why sometimes users who leave in search of "more features" end up coming back because other wallets are too complex, and these users are firmly committed to using our wallets ever since.</p>
     <p>Top-notch crypto investors, individual users of giant whales, exchanges, internet companies, institutional investors... Nearly a million users from 166 countries on five continents are using OneKey, and we have users from every walk of life.</p>
     <p>Ditch frustrating and inefficient decentralization and take security and efficiency to the next level with OneKey's one-stop solution.</p>
-    <p>You need to install **PCSC daemon** to use this app.</p>
+    <p>You need to install PCSC daemon to use this app.</p>
   </description>
 
   <url type="homepage">https://onekey.so</url>

--- a/so.onekey.Wallet.yml
+++ b/so.onekey.Wallet.yml
@@ -74,8 +74,7 @@ modules:
       - ./OneKey-Wallet-linux.AppImage --appimage-extract
       - rm OneKey-Wallet-linux.AppImage
 
-      - desktop-file-edit --set-icon ${FLATPAK_ID} --set-key Exec --set-value 'onekey-wallet
-        %u' squashfs-root/onekey-wallet.desktop
+      - desktop-file-edit --set-icon ${FLATPAK_ID} --set-key Exec --set-value 'onekey-wallet %u' squashfs-root/onekey-wallet.desktop
 
       - install -Dm755 onekey-wallet.sh /app/bin/onekey-wallet
       - install -Dm644 so.onekey.Wallet.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml


### PR DESCRIPTION
## What
- make `onekey-wallet.sh` POSIX `sh` compatible (`set -eu`, remove bash-only `declare`/`[[ ]]`)
- preserve argument boundaries with quoted `"$@"` and use `exec` for the final launch
- normalize desktop `Exec` rewrite to a single-line value (`onekey-wallet %u`)
- fix AppStream description text (remove markdown syntax)
- expand README with PCSC daemon setup across Fedora/Debian/Arch and add network troubleshooting commands

## Why
- avoid shell portability/runtime issues in environments where `/bin/sh` is not bash
- reduce launch edge cases caused by argument splitting
- provide clearer user guidance for PCSC and Flatpak networking diagnostics

## Validation
- `sh -n onekey-wallet.sh`
- `dash -n onekey-wallet.sh`
- XML parse check for `so.onekey.Wallet.metainfo.xml`
