### PR TITLE
Remove only-arches limitation

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,0 @@
-{
-  "only-arches": ["x86_64", "aarch64"],
-  "automerge-flathubbot-prs": false
-}


### PR DESCRIPTION
Since both arches are listed and default behaviour of automerge-flathubbot-prs is false, you can remove the flathub.json file.

See: https://docs.flathub.org/docs/for-app-authors/maintenance#limiting-the-set-of-architectures-to-build-on

> If you build for both x86_64 and aarch64 you do not need a flathub.json file. There will be no new architecture add or removed on current runtimes, which mean that if that situation ever occurred, it would only happen when changing the runtime version in your package.