### PR TITLE
Fix Linux USB access in Flatpak package

### DIFF
--- a/so.onekey.Wallet.yml
+++ b/so.onekey.Wallet.yml
@@ -9,8 +9,10 @@ finish-args:
   - --device=all
   - --share=ipc
   - --share=network
+  - --filesystem=/run/udev:ro
   - --socket=wayland
   - --socket=fallback-x11
+  - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications
   - --socket=pcsc
 modules:
@@ -83,6 +85,7 @@ modules:
       - install -Dm644 squashfs-root/resources/static/images/icons/512x512.png /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
 
       - mv squashfs-root /app/onekey-wallet
+      - chmod +x /app/onekey-wallet/resources/bin/bridge/onekeyd
 
       # To allow separate locales
       # https://searchfox.org/mozilla-central/rev/8a4f55bc09ffc5c25dcb4586c51ae4a9fee77b4c/taskcluster/docker/firefox-flatpak/runme.sh#131-133


### PR DESCRIPTION
## Summary
- Expose `/run/udev` read-only so libusb can read host udev metadata inside the sandbox.
- Grant `org.freedesktop.Flatpak` D-Bus access so the app can use `flatpak-spawn --host pkexec` for one-time host udev rule installation.
- Ensure the packaged `resources/bin/bridge/onekeyd` binary is executable in the extracted AppImage payload.

## Verification
- `git diff --check`
- `flatpak-builder --force-clean --user --install --install-deps-from=flathub --default-branch=codex-test /tmp/onekey-flatpak-build so.onekey.Wallet.yml`
- `flatpak info --show-permissions so.onekey.Wallet//codex-test` includes `devices=all`, `shared=network;ipc`, `filesystems=/run/udev:ro`, and `org.freedesktop.Flatpak=talk`.
- Inside the sandbox, `flatpak-spawn --host sh -c "echo host-spawn-ok"` succeeds.
- Inside the sandbox, `/run/udev/data` is readable.
- Inside the sandbox, `/app/onekey-wallet/resources/bin/bridge/onekeyd` is executable (`755`).
- Inside the sandbox, the connected OneKey USB node `/dev/bus/usb/002/007` is writable after host udev rules are installed.
- Inside the sandbox, network is available (`curl -I https://onekey.so` returns `HTTP/2 200`).

## Runtime note
- This manifest currently packages the released AppImage `v6.2.0`, so runtime behavior still reflects that released app build: it still starts `onekeyd` and still reproduces Electron `DESKTOP_API_CALL: An object could not be cloned` errors.
- The matching app-monorepo PR fixes those runtime issues for the next AppImage used by this manifest.
